### PR TITLE
 Dev

### DIFF
--- a/md-to-docx/MarkdownToDocx.ts
+++ b/md-to-docx/MarkdownToDocx.ts
@@ -8,6 +8,7 @@ import {
   popStyle,
   updateStyle,
   setTextStyle,
+  getSpaceBreakCount,
 } from "./helpers/styles";
 import { writeText } from "./helpers/text";
 import { horizontalLine, lineBreak } from "./helpers/lines";
@@ -71,6 +72,7 @@ export class MarkdownToDocx {
   public popStyle: () => void;
   public updateStyle: (partial?: Partial<MarkdownStyle>) => void;
   public setTextStyle: (type: string) => void;
+  public getSpaceBreakCount: (token: MarkdownToken) => number;
   public writeText: (text: string) => void;
   public lineBreak: () => void;
   public groupParagraph: () => void;
@@ -104,6 +106,7 @@ export class MarkdownToDocx {
     this.popStyle = popStyle.bind(this);
     this.updateStyle = updateStyle.bind(this);
     this.setTextStyle = setTextStyle.bind(this);
+    this.getSpaceBreakCount = getSpaceBreakCount.bind(this);
     this.writeText = writeText.bind(this);
     this.lineBreak = lineBreak.bind(this);
     this.groupParagraph = groupParagraph.bind(this);

--- a/md-to-docx/helpers/code.ts
+++ b/md-to-docx/helpers/code.ts
@@ -11,6 +11,7 @@ export function writeCode(this: MarkdownToDocxContext, token: MarkdownCodeToken)
   }
 
   this.groupParagraph();
+  this.lineBreak();
 }
 
 export function writeCodeSpan(this: MarkdownToDocxContext, token: MarkdownCodeSpanToken): void {

--- a/md-to-docx/helpers/html.ts
+++ b/md-to-docx/helpers/html.ts
@@ -1,0 +1,12 @@
+import type { MarkdownToken } from "../types";
+
+export function getLiteralTokenText(token: MarkdownToken): string {
+  if ("raw" in token && token.raw !== undefined && typeof token.raw === "string") {
+    return token.raw;
+  }
+  if ("text" in token && token.text !== undefined && typeof token.text === "string") {
+    return token.text;
+  }
+
+  return "";
+}

--- a/md-to-docx/helpers/list.ts
+++ b/md-to-docx/helpers/list.ts
@@ -21,8 +21,8 @@ export function writeList(this: MarkdownToDocxContext, token: MarkdownListToken)
     ordered: Boolean(token.ordered),
   });
 
-  const items = (token.items || []) as MarkdownListItemToken[];
-  const start = Number(token.start) || 1;
+  const items = token.items || [];
+  const start = token.start != null ? Number(token.start) : 1;
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i];

--- a/md-to-docx/helpers/styles.ts
+++ b/md-to-docx/helpers/styles.ts
@@ -1,7 +1,7 @@
 import docx = require("./docx");
-import type { DocxHeadingLevel, MarkdownStyle, MarkdownToDocxContext } from "../types";
+import type { DocxHeadingLevel, MarkdownStyle, MarkdownToDocxContext, MarkdownToken } from "../types";
 
-const _DEFAULT_STYLE: MarkdownStyle = {
+const DEFAULT_STYLE: MarkdownStyle = {
   font: "Arial",
   textColor: "333333",
   linkColor: "0000EE",
@@ -29,7 +29,7 @@ const _HEADING_MAP: Array<DocxHeadingLevel | null> = [
 ];
 
 export function getDefaultStyle(): MarkdownStyle {
-  return { ..._DEFAULT_STYLE };
+  return { ...DEFAULT_STYLE };
 }
 
 export function getHeadingMap(): Array<DocxHeadingLevel | null> {
@@ -77,4 +77,18 @@ export function setTextStyle(this: MarkdownToDocxContext, type: string): void {
     default:
       break;
   }
+}
+
+export function getSpaceBreakCount(this: MarkdownToDocxContext, token: MarkdownToken): number {
+  if (token.type !== "space") {
+    return 1;
+  }
+
+  // Marked encodes a single blank line between blocks as raw "\n\n". The
+  // following block renderer already adds its own leading break, so convert raw
+  // newline count into blank-line count to avoid double-spacing.
+  const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+  const newlineCount = (raw.match(/\n/g) || []).length;
+
+  return Math.max(1, newlineCount - 1);
 }

--- a/md-to-docx/helpers/text.ts
+++ b/md-to-docx/helpers/text.ts
@@ -1,35 +1,41 @@
 import docx = require("./docx");
 import type { IRunOptions } from "docx";
-import type { MarkdownToDocxContext, MarkdownToken } from "../types";
-
-export function getLiteralTokenText(token: MarkdownToken): string {
-  if ("raw" in token && token.raw !== undefined && typeof token.raw === "string") {
-    return token.raw;
-  }
-  if ("text" in token && token.text !== undefined && typeof token.text === "string") {
-    return token.text;
-  }
-
-  return "";
-}
+import type { MarkdownToDocxContext } from "../types";
 
 export function writeText(this: MarkdownToDocxContext, text: string): void {
   const currentTextRuns = this.getCurrentTextRuns();
-  const options: IRunOptions = {
-    text,
-    font: this.style.font,
-    bold: this.style.bold,
-    ...(!this.style.headingLevel
-      ? {
-          size: this.style.fontSize,
-          color: this.style.textColor,
-          italics: this.style.italics,
-          strike: this.style.strike,
-        }
-      : {}),
-    ...(this.style.link ? { style: "Hyperlink" } : {}),
-  };
+  // Create one run per visual line so explicit newlines survive DOCX export.
+  const chunks = String(text || "").split("\n");
 
-  currentTextRuns.push(new docx.TextRun(options));
+  for (let index = 0; index < chunks.length; index += 1) {
+    const options: IRunOptions = {
+      text: chunks[index] || "",
+      font: this.style.font,
+      bold: this.style.bold,
+      ...(!this.style.headingLevel
+        ? {
+            size: this.style.fontSize,
+            color: this.style.textColor,
+            italics: this.style.italics,
+            strike: this.style.strike,
+          }
+        : {}),
+      ...(this.style.link ? { style: "Hyperlink" } : {}),
+    };
+
+    currentTextRuns.push(new docx.TextRun(options));
+
+    if (index < chunks.length - 1) {
+      // DOCX line breaks are represented as an empty run with `break: 1`.
+      currentTextRuns.push(
+        new docx.TextRun({
+          text: "",
+          size: this.style.fontSize,
+          break: 1,
+        })
+      );
+    }
+  }
+
   this.setCurrentTextRuns(currentTextRuns);
 }

--- a/md-to-docx/processors/child.ts
+++ b/md-to-docx/processors/child.ts
@@ -8,7 +8,7 @@ import type {
   MarkdownToDocxContext,
   MarkdownToken,
 } from "../types";
-import { getLiteralTokenText } from "../helpers/text";
+import { getLiteralTokenText } from "../helpers/html";
 
 export function processChild(this: MarkdownToDocxContext, token: MarkdownToken): void {
   // save current style on stack
@@ -53,9 +53,15 @@ export function processChild(this: MarkdownToDocxContext, token: MarkdownToken):
       this.writeList(token as MarkdownListToken);
       break;
     // space
-    case "space":
-      this.lineBreak();
+    case "space": {
+      // Preserve explicit blank-line runs by expanding the raw newline count.
+      const breakCount = this.getSpaceBreakCount(token);
+
+      for (let i = 0; i < breakCount; i += 1) {
+        this.lineBreak();
+      }
       break;
+    }
     // table
     case "table":
       this.groupParagraph();

--- a/md-to-docx/tests/MarkdownToDocx.test.ts
+++ b/md-to-docx/tests/MarkdownToDocx.test.ts
@@ -58,6 +58,7 @@ describe("MarkdownToDocx class", () => {
       expect(typeof doc.popStyle).toBe("function");
       expect(typeof doc.updateStyle).toBe("function");
       expect(typeof doc.setTextStyle).toBe("function");
+      expect(typeof doc.getSpaceBreakCount).toBe("function");
       expect(typeof doc.writeText).toBe("function");
       expect(typeof doc.lineBreak).toBe("function");
       expect(typeof doc.groupParagraph).toBe("function");

--- a/md-to-docx/tests/processors/child.test.ts
+++ b/md-to-docx/tests/processors/child.test.ts
@@ -17,6 +17,7 @@ describe("child.js processors", () => {
       writeLink: jest.fn(),
       writeList: jest.fn(),
       processTable: jest.fn(),
+      getSpaceBreakCount: jest.fn(() => 1),
     };
   });
 
@@ -99,6 +100,17 @@ describe("child.js processors", () => {
       processChild.call(mockContext, token);
 
       expect(mockContext.lineBreak).toHaveBeenCalled();
+      expect(mockContext.getSpaceBreakCount).toHaveBeenCalledWith(token);
+    });
+
+    it("should handle space type with multiple newline breaks", () => {
+      mockContext.getSpaceBreakCount.mockReturnValue(3);
+      const token = { type: "space", raw: "\n\n\n" };
+
+      processChild.call(mockContext, token);
+
+      expect(mockContext.lineBreak).toHaveBeenCalledTimes(3);
+      expect(mockContext.getSpaceBreakCount).toHaveBeenCalledWith(token);
     });
 
     it("should handle table type", () => {

--- a/md-to-docx/tests/unit_tests/code.test.ts
+++ b/md-to-docx/tests/unit_tests/code.test.ts
@@ -69,7 +69,7 @@ describe("code.js helpers", () => {
       const token = { lines, codeBlockStyle: false };
       writeCode.call(mockContext, token);
 
-      expect(mockContext.lineBreak).toHaveBeenCalledTimes(2);
+      expect(mockContext.lineBreak).toHaveBeenCalledTimes(3);
     });
 
     it("should increment indent level when codeBlockStyle is true", () => {
@@ -99,7 +99,7 @@ describe("code.js helpers", () => {
       writeCode.call(mockContext, token);
 
       expect(mockContext.writeText).not.toHaveBeenCalled();
-      expect(mockContext.lineBreak).not.toHaveBeenCalled();
+      expect(mockContext.lineBreak).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/md-to-docx/tests/unit_tests/list.test.ts
+++ b/md-to-docx/tests/unit_tests/list.test.ts
@@ -159,15 +159,15 @@ describe("list.js helpers", () => {
       expect(token.items[0].prefix).toBe("5. ");
     });
 
-    it("should default ordered list numbering to 1 when start is empty", () => {
+    it("should preserve ordered list numbering when start is zero", () => {
       const token = {
         ordered: true,
-        start: "",
+        start: 0,
         items: [{ type: "list_item", tokens: [] }],
       };
       writeList.call(mockContext, token);
 
-      expect(token.items[0].prefix).toBe("1. ");
+      expect(token.items[0].prefix).toBe("0. ");
     });
 
     it("should handle empty items array", () => {

--- a/md-to-docx/tests/unit_tests/styles.test.ts
+++ b/md-to-docx/tests/unit_tests/styles.test.ts
@@ -5,6 +5,7 @@ const {
   popStyle,
   updateStyle,
   setTextStyle,
+  getSpaceBreakCount,
 } = require("../../helpers/styles");
 const docx = require("docx");
 
@@ -375,6 +376,21 @@ describe("styles.js helpers", () => {
       expect(() => {
         setTextStyle.call(mockContext, undefined);
       }).not.toThrow();
+    });
+  });
+
+  describe("getSpaceBreakCount", () => {
+    it("should return 1 for non-space tokens", () => {
+      expect(getSpaceBreakCount.call(mockContext, { type: "text", raw: "\n\n\n" })).toBe(1);
+    });
+
+    it("should convert raw newline count into blank-line count", () => {
+      expect(getSpaceBreakCount.call(mockContext, { type: "space", raw: "\n\n" })).toBe(1);
+      expect(getSpaceBreakCount.call(mockContext, { type: "space", raw: "\n\n\n" })).toBe(2);
+    });
+
+    it("should default to 1 when raw is missing", () => {
+      expect(getSpaceBreakCount.call(mockContext, { type: "space" })).toBe(1);
     });
   });
 });

--- a/md-to-docx/tests/unit_tests/text.test.ts
+++ b/md-to-docx/tests/unit_tests/text.test.ts
@@ -38,6 +38,7 @@ describe("text.js helpers", () => {
       this.italics = options?.italics;
       this.strike = options?.strike;
       this.style = options?.style;
+      this.break = options?.break;
     });
   });
 
@@ -153,7 +154,14 @@ describe("text.js helpers", () => {
     it("should handle multiline text", () => {
       writeText.call(mockContext, "Line 1\nLine 2\nLine 3");
 
-      expect(mockContext.getCurrentTextRuns()[0].text).toBe("Line 1\nLine 2\nLine 3");
+      const runs = mockContext.getCurrentTextRuns();
+
+      expect(runs.length).toBe(5);
+      expect(runs[0].text).toBe("Line 1");
+      expect(runs[1].break).toBe(1);
+      expect(runs[2].text).toBe("Line 2");
+      expect(runs[3].break).toBe(1);
+      expect(runs[4].text).toBe("Line 3");
     });
 
     it("should add multiple TextRuns to current", () => {

--- a/md-to-docx/types.ts
+++ b/md-to-docx/types.ts
@@ -12,8 +12,10 @@ export type MarkdownHeadingToken = Tokens.Heading;
 export type MarkdownBlockquoteToken = Tokens.Blockquote;
 export type MarkdownLinkToken = Tokens.Link | Tokens.Image;
 export type MarkdownCheckboxToken = Tokens.Checkbox | Tokens.ListItem;
-export type MarkdownListToken = Tokens.List;
+// Extend ListItem with a prefix for our purposes
 export type MarkdownListItemToken = Tokens.ListItem & { prefix?: string };
+// Since we extend ListItem, we need to redefine List to use our extended ListItem
+export type MarkdownListToken = Omit<Tokens.List, "items"> & { items: MarkdownListItemToken[] };
 export type MarkdownCodeSpanToken = Tokens.Codespan;
 export type MarkdownCodeToken = Tokens.Code & { lines?: string[] };
 export type MarkdownTableToken = Tokens.Table;
@@ -47,6 +49,7 @@ export interface MarkdownToDocxContext {
   popStyle: () => void;
   updateStyle: (partial?: Partial<MarkdownStyle>) => void;
   setTextStyle: (type: string) => void;
+  getSpaceBreakCount: (token: MarkdownToken) => number;
   writeText: (text: string) => void;
   lineBreak: () => void;
   groupParagraph: () => void;

--- a/md-to-pdf/MarkdownToPdf.ts
+++ b/md-to-pdf/MarkdownToPdf.ts
@@ -4,6 +4,7 @@ import {
   popStyle,
   updateStyle,
   setTextStyle,
+  getSpaceBreakCount,
   setDocStyle,
 } from "./helpers/styles";
 import { horizontalLine, lineBreak } from "./helpers/lines";
@@ -12,6 +13,7 @@ import { processTable } from "./helpers/table";
 import { writeCheckBox, writeList, writeListItem } from "./helpers/list";
 import { writeCode, writeCodeSpan } from "./helpers/code";
 import { writeBlockquote } from "./helpers/blockquote";
+import { writeHtml } from "./helpers/html";
 import { writeHeading } from "./helpers/heading";
 import { writeLink } from "./helpers/link";
 import { writeParagraph } from "./helpers/paragraph";
@@ -69,6 +71,7 @@ export class MarkdownToPdf {
   public popStyle: () => void;
   public updateStyle: (partial?: Partial<PdfStyle>) => void;
   public setTextStyle: (type: string) => void;
+  public getSpaceBreakCount: (token: MarkdownToken) => number;
   public lineBreak: (distance: number) => void;
   public horizontalLine: () => void;
   public writePrefix: (token: MarkdownListItemToken | MarkdownCheckboxToken) => PdfStyle;
@@ -80,6 +83,7 @@ export class MarkdownToPdf {
   public writeListItem: (token: MarkdownListItemToken) => void;
   public writeCode: (token: MarkdownCodeToken) => void;
   public writeCodeSpan: (token: MarkdownCodeSpanToken) => void;
+  public writeHtml: (token: MarkdownToken) => void;
   public writeBlockquote: (token: MarkdownBlockquoteToken) => void;
   public writeHeading: (token: MarkdownHeadingToken) => void;
   public writeParagraph: (token: MarkdownParagraphToken) => void;
@@ -103,6 +107,7 @@ export class MarkdownToPdf {
     this.popStyle = popStyle.bind(this);
     this.updateStyle = updateStyle.bind(this);
     this.setTextStyle = setTextStyle.bind(this);
+    this.getSpaceBreakCount = getSpaceBreakCount.bind(this);
     this.lineBreak = lineBreak.bind(this);
     this.horizontalLine = horizontalLine.bind(this);
     this.writePrefix = writePrefix.bind(this);
@@ -113,6 +118,7 @@ export class MarkdownToPdf {
     this.writeListItem = writeListItem.bind(this);
     this.writeCode = writeCode.bind(this);
     this.writeCodeSpan = writeCodeSpan.bind(this);
+    this.writeHtml = writeHtml.bind(this);
     this.writeBlockquote = writeBlockquote.bind(this);
     this.writeHeading = writeHeading.bind(this);
     this.writeLink = writeLink.bind(this);

--- a/md-to-pdf/helpers/html.ts
+++ b/md-to-pdf/helpers/html.ts
@@ -1,0 +1,37 @@
+import type { MarkdownToPdfContext, MarkdownToken } from "../types";
+
+export function getLiteralTokenText(token: MarkdownToken): string {
+  if ("raw" in token && token.raw && typeof token.raw === "string") {
+    return token.raw;
+  }
+  if ("text" in token && token.text && typeof token.text === "string") {
+    return token.text;
+  }
+
+  return "";
+}
+
+function getTrailingNewlineCount(raw: string): number {
+  // Only trailing newlines matter for spacing after a rendered HTML block.
+  const match = String(raw || "").match(/\n+$/);
+
+  return match ? match[0].length : 0;
+}
+
+export function writeHtml(this: MarkdownToPdfContext, token: MarkdownToken): void {
+  // Keep raw HTML visible in output instead of dropping unsupported tokens.
+  const rawText = getLiteralTokenText(token);
+  this.writeText(rawText);
+
+  // Block HTML tokens can carry trailing newlines in `raw`. Preserve blank
+  // lines that would otherwise be lost when rendered as literal text.
+  const isBlockHtml = "block" in token && Boolean((token as any).block);
+  if (isBlockHtml) {
+    const trailingNewlines = getTrailingNewlineCount(rawText);
+    const extraBreaks = Math.max(0, trailingNewlines - 1);
+
+    for (let i = 0; i < extraBreaks; i += 1) {
+      this.lineBreak(this.getStyle().lineDistance);
+    }
+  }
+}

--- a/md-to-pdf/helpers/list.ts
+++ b/md-to-pdf/helpers/list.ts
@@ -11,14 +11,6 @@ export function writeCheckBox(this: MarkdownToPdfContext, token: MarkdownCheckbo
 }
 
 export function writeList(this: MarkdownToPdfContext, token: MarkdownListToken): void {
-  const initialStyle = this.getStyle();
-
-  // Nested lists can appear after inline text inside a list item; force the
-  // nested list to start on a fresh line so prefixes do not collide with text.
-  if (initialStyle.cursorIndex > initialStyle.currentWidth) {
-    this.lineBreak(initialStyle.lineDistance);
-  }
-
   const startStyle = this.getStyle();
 
   // add bullet point prefix area and increase indent level
@@ -28,10 +20,10 @@ export function writeList(this: MarkdownToPdfContext, token: MarkdownListToken):
   });
 
   const items = token.items || [];
-  const start = Number(token.start) || 1;
+  const start = token.start != null ? Number(token.start) : 1;
 
   for (let index = 0; index < items.length; index += 1) {
-    const item = items[index] as MarkdownListItemToken;
+    const item = items[index];
     // if ordered, replace bullet point with current index for numbering
     if (token.ordered) {
       item.prefix = `${start + index}. `;
@@ -47,8 +39,11 @@ export function writeListItem(this: MarkdownToPdfContext, token: MarkdownListIte
   this.lineBreak(token.loose ? style.lineSpc : style.lineDistance);
 
   this.writePrefix(token);
-  // The first paragraph in an item should continue after the prefix, not add
-  // another paragraph break before content.
-  this.updateStyle({ skipParagraphBreak: true });
-  this.DFS(token.tokens || []);
+  const itemTokens = token.tokens || [];
+
+  // Only suppress the paragraph break when the list item actually starts with
+  // a paragraph token. Non-paragraph item starts (for example plain text or a
+  // nested list) should not leak skipParagraphBreak into following blocks.
+  this.updateStyle({ skipParagraphBreak: itemTokens[0]?.type === "paragraph" });
+  this.DFS(itemTokens);
 }

--- a/md-to-pdf/helpers/styles.ts
+++ b/md-to-pdf/helpers/styles.ts
@@ -1,8 +1,8 @@
 import jspdfFonts = require("../jspdfFonts");
 
-import type { JsPdfDoc, MarkdownToPdfContext, PdfStyle } from "../types";
+import type { JsPdfDoc, MarkdownToPdfContext, MarkdownToken, PdfStyle } from "../types";
 
-const _DEFAULT_STYLE: PdfStyle = {
+const DEFAULT_STYLE: PdfStyle = {
   font: "helvetica",
   monospaceFont: "courier",
   lineDistance: 10,
@@ -29,7 +29,7 @@ const _DEFAULT_STYLE: PdfStyle = {
 };
 
 export function getDefaultStyle(): PdfStyle {
-  return { ..._DEFAULT_STYLE };
+  return { ...DEFAULT_STYLE };
 }
 
 export function pushStyle(this: MarkdownToPdfContext): void {
@@ -82,6 +82,20 @@ export function setTextStyle(this: MarkdownToPdfContext, type: string): void {
   }
 }
 
+export function getSpaceBreakCount(this: MarkdownToPdfContext, token: MarkdownToken): number {
+  if (token.type !== "space") {
+    return 1;
+  }
+
+  // Marked encodes a single blank line between blocks as raw "\n\n". The
+  // following block renderer already adds its own leading break, so convert raw
+  // newline count into blank-line count to avoid double-spacing.
+  const raw = "raw" in token && typeof token.raw === "string" ? token.raw : "";
+  const newlineCount = (raw.match(/\n/g) || []).length;
+
+  return Math.max(1, newlineCount - 1);
+}
+
 export function checkHeight(doc: JsPdfDoc, style: PdfStyle): number {
   if (style.currentHeight + style.lineSpc > style.pageHeight) {
     doc.addPage();
@@ -94,11 +108,6 @@ export function checkHeight(doc: JsPdfDoc, style: PdfStyle): number {
 export function setDocStyle(doc: JsPdfDoc, text: string, style: PdfStyle): void {
   const font = jspdfFonts.chooseFontForText(text, style.code ? style.monospaceFont : style.font);
 
-  doc.setFont(font);
-  doc.setFontSize(style.fontSize);
-  doc.setTextColor(style.textColor);
-  doc.setDrawColor(style.drawColor);
-
   // jsPDF uses style variants per font family, so map boolean flags to variant.
   if (style.bold && style.italics) {
     doc.setFont(font, "bolditalic");
@@ -109,4 +118,7 @@ export function setDocStyle(doc: JsPdfDoc, text: string, style: PdfStyle): void 
   } else {
     doc.setFont(font, "normal");
   }
+  doc.setFontSize(style.fontSize);
+  doc.setTextColor(style.textColor);
+  doc.setDrawColor(style.drawColor);
 }

--- a/md-to-pdf/helpers/table.ts
+++ b/md-to-pdf/helpers/table.ts
@@ -34,7 +34,10 @@ export function processTable(this: MarkdownToPdfContext, token: MarkdownTableTok
     }));
   });
 
-  this.lineBreak(style.lineDistance);
+  // If we're currently mid-line, move to the next line before starting the table.
+  if (style.cursorIndex > style.currentWidth) {
+    this.lineBreak(style.lineDistance);
+  }
   const nextStyle = { ...this.getStyle() };
 
   // create the table with the generated rows
@@ -43,7 +46,7 @@ export function processTable(this: MarkdownToPdfContext, token: MarkdownTableTok
     body: tableData,
     startY: nextStyle.currentHeight,
     tableWidth: nextStyle.maxLineWidth - nextStyle.currentWidth,
-    pageBreak: "avoid",
+    pageBreak: "auto",
     margin: {
       left: nextStyle.currentWidth,
     },

--- a/md-to-pdf/helpers/text.ts
+++ b/md-to-pdf/helpers/text.ts
@@ -3,20 +3,9 @@ import type {
   MarkdownCheckboxToken,
   MarkdownListItemToken,
   MarkdownToPdfContext,
-  MarkdownToken,
+  JsPdfDoc,
   PdfStyle,
 } from "../types";
-
-export function getLiteralTokenText(token: MarkdownToken): string {
-  if ("raw" in token && token.raw !== undefined && typeof token.raw === "string") {
-    return token.raw;
-  }
-  if ("text" in token && token.text !== undefined && typeof token.text === "string") {
-    return token.text;
-  }
-
-  return "";
-}
 
 export function writePrefix(
   this: MarkdownToPdfContext,
@@ -25,10 +14,72 @@ export function writePrefix(
   let style = this.getStyle();
 
   if (token.prefix) {
-    style = this.writeText(String(token.prefix || ""));
+    style = this.writeText(token.prefix);
   }
 
   return style;
+}
+
+export function chooseSplitWidth(
+  text: string,
+  remainingWidth: number,
+  fullLineWidth: number,
+  doc: JsPdfDoc
+): number {
+  // Clamp widths so splitTextToSize always receives a safe positive value.
+  const safeFullLineWidth = Math.max(Number(fullLineWidth) || 0, 1);
+  const safeRemainingWidth =
+    remainingWidth > 0 ? Math.min(remainingWidth, safeFullLineWidth) : safeFullLineWidth;
+  // Only the first visible word matters for deciding whether wrapping should
+  // stay on the current line or move to a fresh full-width line.
+  const firstWord = String(text || "").trimStart().match(/\S+/)?.[0] || "";
+
+  if (!firstWord) {
+    return safeRemainingWidth;
+  }
+
+  const firstWordWidth = doc.getTextWidth(firstWord);
+
+  // If the first word does not fit in remaining width but does fit a fresh line,
+  // split using full-line width to avoid tiny fragmented chunks.
+  if (firstWordWidth > safeRemainingWidth && firstWordWidth <= safeFullLineWidth) {
+    return safeFullLineWidth;
+  }
+
+  return safeRemainingWidth;
+}
+
+function splitTextAtWidth(text: string, maxWidth: number, doc: JsPdfDoc): { firstPiece: string; restText: string } {
+  // Split into alternating whitespace/non-whitespace segments so slicing the
+  // remainder preserves the original spacing exactly.
+  const segments = String(text || "").match(/\s+|\S+/g) || [];
+
+  if (segments.length === 0) {
+    return { firstPiece: "", restText: "" };
+  }
+
+  let consumedLength = 0;
+  let currentText = "";
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    const candidate = currentText + segment;
+
+    // Always accept the first segment, then stop as soon as adding the next
+    // segment would exceed the allowed width.
+    if (currentText.length === 0 || doc.getTextWidth(candidate) <= maxWidth) {
+      currentText = candidate;
+      consumedLength += segment.length;
+      continue;
+    }
+
+    return {
+      firstPiece: text.slice(0, consumedLength),
+      restText: text.slice(consumedLength),
+    };
+  }
+
+  return { firstPiece: text, restText: "" };
 }
 
 export function writeText(this: MarkdownToPdfContext, text: string): PdfStyle {
@@ -39,9 +90,31 @@ export function writeText(this: MarkdownToPdfContext, text: string): PdfStyle {
 
   // split text into components that will not exceed the maximum line width
   this.setDocStyle(doc, text, style);
-  const splitText = doc.splitTextToSize(text, style.maxLineWidth - style.cursorIndex);
 
-  for (const piece of splitText) {
+  const fullLineWidth = style.maxLineWidth - style.currentWidth;
+  const remainingWidth = style.maxLineWidth - Math.max(style.cursorIndex, style.currentWidth);
+  const splitWidth = chooseSplitWidth(text, remainingWidth, fullLineWidth, doc);
+
+  // Normalize split output so downstream width checks are string-safe.
+  let splitText = doc.splitTextToSize(text, splitWidth).map((piece) => String(piece || ""));
+
+  // If text starts mid-line and wraps, only the first visual line should use the
+  // remaining width. Continuation lines should use the full line width.
+  if (splitWidth < Math.max(fullLineWidth, 1) && splitText.length > 1) {
+    // Re-slice the original text instead of reconstructing from split output so
+    // continuation text keeps the original whitespace layout.
+    const { firstPiece, restText } = splitTextAtWidth(text, splitWidth, doc);
+    const restFromOriginal = restText.trimStart();
+
+    if (restFromOriginal.length > 0) {
+      // Reflow only the continuation against the full available line width.
+      splitText = [firstPiece, ...doc.splitTextToSize(restFromOriginal, Math.max(fullLineWidth, 1))];
+    }
+  }
+
+  for (let index = 0; index < splitText.length; index += 1) {
+    const piece = splitText[index];
+
     // Guard for long fragments that still exceed width after splitting.
     if (style.cursorIndex + doc.getTextWidth(piece) > style.maxLineWidth) {
       style.currentHeight += style.lineDistance;
@@ -72,6 +145,14 @@ export function writeText(this: MarkdownToPdfContext, text: string): PdfStyle {
     }
 
     style.cursorIndex += doc.getTextWidth(piece);
+
+    // splitTextToSize returns visual lines, so always advance after each
+    // non-final piece to preserve wrapping and word boundaries.
+    if (index < splitText.length - 1) {
+      style.currentHeight += style.lineDistance;
+      style.cursorIndex = style.currentWidth;
+      style.currentHeight = checkHeight(doc, style);
+    }
   }
 
   this.setStyle(style);

--- a/md-to-pdf/processors/child.ts
+++ b/md-to-pdf/processors/child.ts
@@ -8,7 +8,6 @@ import type {
   MarkdownToPdfContext,
   MarkdownToken,
 } from "../types";
-import { getLiteralTokenText } from "../helpers/text";
 
 export function processChild(this: MarkdownToPdfContext, token: MarkdownToken): void {
   // save current style on stack
@@ -39,9 +38,10 @@ export function processChild(this: MarkdownToPdfContext, token: MarkdownToken): 
       this.horizontalLine();
       break;
     // Render raw HTML tokens as literal text so content is not silently lost.
-    case "html":
-      this.writeText(getLiteralTokenText(token));
+    case "html": {
+      this.writeHtml(token);
       break;
+    }
     // image
     case "image":
       this.writeLink(token as MarkdownLinkToken);
@@ -51,9 +51,15 @@ export function processChild(this: MarkdownToPdfContext, token: MarkdownToken): 
       this.writeList(token as MarkdownListToken);
       break;
     // space
-    case "space":
-      this.lineBreak(this.getStyle().lineDistance);
+    case "space": {
+      // Preserve explicit blank-line runs by expanding the raw newline count.
+      const breakCount = this.getSpaceBreakCount(token);
+
+      for (let i = 0; i < breakCount; i += 1) {
+        this.lineBreak(this.getStyle().lineDistance);
+      }
       break;
+    }
     // table
     case "table":
       this.processTable(token as MarkdownTableToken);

--- a/md-to-pdf/tests/MarkdownToPdf.test.ts
+++ b/md-to-pdf/tests/MarkdownToPdf.test.ts
@@ -43,7 +43,9 @@ describe("MarkdownToPdf class", () => {
     expect(typeof pdf.popStyle).toBe("function");
     expect(typeof pdf.updateStyle).toBe("function");
     expect(typeof pdf.setTextStyle).toBe("function");
+    expect(typeof pdf.getSpaceBreakCount).toBe("function");
     expect(typeof pdf.writeText).toBe("function");
+    expect(typeof pdf.writeHtml).toBe("function");
     expect(typeof pdf.lineBreak).toBe("function");
     expect(typeof pdf.horizontalLine).toBe("function");
     expect(typeof pdf.processParent).toBe("function");

--- a/md-to-pdf/tests/integration/convert.integration.test.ts
+++ b/md-to-pdf/tests/integration/convert.integration.test.ts
@@ -95,4 +95,97 @@ describe("integration: markdown to pdf", () => {
     expect(doc.rect.mock.calls[1][1]).toBeLessThan(70);
     expect(doc.rect.mock.calls[1][3]).toBeLessThan(50);
   });
+
+  it("should place paragraph text on a new line after block html following a list", () => {
+    marked.lexer.mockImplementationOnce(() => [
+      {
+        type: "list",
+        ordered: false,
+        loose: false,
+        items: [
+          {
+            type: "list_item",
+            loose: false,
+            task: false,
+            tokens: [
+              {
+                type: "text",
+                tokens: [{ type: "text", text: "Item" }],
+              },
+            ],
+          },
+        ],
+      },
+      { type: "space" },
+      { type: "html", block: true, raw: "<div> This is a div </div>\n\n" },
+      { type: "paragraph", tokens: [{ type: "text", text: "This is text" }] },
+    ]);
+
+    const api = createMdToPdf();
+    const doc = createMockDoc();
+
+    api.convert(doc, "fixture", {
+      currentHeight: 70,
+      currentWidth: 60,
+      lineDistance: 10,
+      lineSpc: 18,
+    });
+
+    const htmlCall = doc.text.mock.calls.find((call) => String(call[0]).includes("</div>"));
+    const paragraphCall = doc.text.mock.calls.find((call) => String(call[0]) === "This is text");
+
+    expect(htmlCall).toBeDefined();
+    expect(paragraphCall).toBeDefined();
+    expect(paragraphCall[2] - htmlCall[2]).toBe(20);
+  });
+
+  it("should not insert an extra blank line before nested list items", () => {
+    marked.lexer.mockImplementationOnce(() => [
+      {
+        type: "list",
+        ordered: false,
+        loose: false,
+        items: [
+          {
+            type: "list_item",
+            loose: false,
+            task: false,
+            tokens: [
+              { type: "text", text: "Parent" },
+              {
+                type: "list",
+                ordered: false,
+                loose: false,
+                items: [
+                  {
+                    type: "list_item",
+                    loose: false,
+                    task: false,
+                    tokens: [{ type: "text", text: "Child" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const api = createMdToPdf();
+    const doc = createMockDoc();
+
+    api.convert(doc, "fixture", {
+      currentHeight: 70,
+      currentWidth: 60,
+      lineDistance: 10,
+      lineSpc: 18,
+    });
+
+    const parentCall = doc.text.mock.calls.find((call) => String(call[0]) === "Parent");
+    const childCall = doc.text.mock.calls.find((call) => String(call[0]) === "Child");
+
+    expect(parentCall).toBeDefined();
+    expect(childCall).toBeDefined();
+    expect(childCall[2] - parentCall[2]).toBe(10);
+  });
 });

--- a/md-to-pdf/tests/processors/child.test.ts
+++ b/md-to-pdf/tests/processors/child.test.ts
@@ -11,12 +11,14 @@ describe("md-to-pdf child processor", () => {
       writeCheckBox: jest.fn(),
       writeCode: jest.fn(),
       writeCodeSpan: jest.fn(),
+      writeHtml: jest.fn(),
       horizontalLine: jest.fn(),
       writeLink: jest.fn(),
       writeList: jest.fn(),
       processTable: jest.fn(),
       writeText: jest.fn(),
       getStyle: jest.fn(() => ({ lineDistance: 10 })),
+      getSpaceBreakCount: jest.fn(() => 1),
     };
   });
 
@@ -33,6 +35,18 @@ describe("md-to-pdf child processor", () => {
 
     expect(context.lineBreak).toHaveBeenCalledTimes(2);
     expect(context.lineBreak).toHaveBeenCalledWith(10);
+    expect(context.getSpaceBreakCount).toHaveBeenCalledWith({ type: "space" });
+  });
+
+  it("should break multiple lines for space based on newline count", () => {
+    context.getSpaceBreakCount.mockReturnValue(3);
+
+    processChild.call(context, { type: "space", raw: "\n\n\n" });
+
+    expect(context.lineBreak).toHaveBeenCalledTimes(3);
+    expect(context.lineBreak).toHaveBeenNthCalledWith(1, 10);
+    expect(context.lineBreak).toHaveBeenNthCalledWith(2, 10);
+    expect(context.lineBreak).toHaveBeenNthCalledWith(3, 10);
   });
 
   it("should route to dedicated handlers", () => {
@@ -68,6 +82,12 @@ describe("md-to-pdf child processor", () => {
   it("should render html tokens as literal text", () => {
     processChild.call(context, { type: "html", raw: "<div class=\"note\">x</div>" });
 
-    expect(context.writeText).toHaveBeenCalledWith("<div class=\"note\">x</div>");
+    expect(context.writeHtml).toHaveBeenCalledWith({ type: "html", raw: "<div class=\"note\">x</div>" });
+  });
+
+  it("should preserve blank line after block html with trailing newlines", () => {
+    processChild.call(context, { type: "html", block: true, raw: "<div>x</div>\n\n" });
+
+    expect(context.writeHtml).toHaveBeenCalledWith({ type: "html", block: true, raw: "<div>x</div>\n\n" });
   });
 });

--- a/md-to-pdf/tests/unit_tests/list.test.ts
+++ b/md-to-pdf/tests/unit_tests/list.test.ts
@@ -65,7 +65,7 @@ describe("md-to-pdf list helpers", () => {
     expect(context.DFS).toHaveBeenCalledTimes(2);
   });
 
-  it("writeList should default ordered start to 1 when start is invalid", () => {
+  it("writeList should preserve ordered start when it is zero", () => {
     const style = ({ ...getDefaultStyle(), ...{ currentWidth: 60, cursorIndex: 60, currentHeight: 80, indent: 8 } });
     const context = {
       style,
@@ -92,16 +92,16 @@ describe("md-to-pdf list helpers", () => {
 
     const token = {
       ordered: true,
-      start: "NaN",
+      start: 0,
       items: [{ tokens: [] }],
     };
 
     writeList.call(context, token);
 
-    expect(token.items[0].prefix).toBe("1. ");
+    expect(token.items[0].prefix).toBe("0. ");
   });
 
-  it("writeListItem should create line break and set skipParagraphBreak", () => {
+  it("writeListItem should create line break and set skipParagraphBreak for paragraph items", () => {
     const context = {
       style: ({ ...getDefaultStyle(), ...{ lineDistance: 10, lineSpc: 18 } }),
       getStyle() {
@@ -118,7 +118,13 @@ describe("md-to-pdf list helpers", () => {
     };
 
     const before = context.style.currentHeight;
-    const token = { loose: false, task: true, checked: false, prefix: "1. ", tokens: [] };
+    const token = {
+      loose: false,
+      task: true,
+      checked: false,
+      prefix: "1. ",
+      tokens: [{ type: "paragraph", tokens: [] }],
+    };
 
     writeListItem.call(context, token);
 
@@ -126,6 +132,34 @@ describe("md-to-pdf list helpers", () => {
     expect(context.style.currentHeight).toBeGreaterThan(before);
     expect(token.prefix).toBe("1. ");
     expect(context.style.skipParagraphBreak).toBe(true);
+  });
+
+  it("writeListItem should not set skipParagraphBreak for non-paragraph item starts", () => {
+    const context = {
+      style: ({ ...getDefaultStyle(), ...{ lineDistance: 10, lineSpc: 18 } }),
+      getStyle() {
+        return this.style;
+      },
+      lineBreak: jest.fn(function(distance) {
+        this.style.currentHeight += distance;
+      }),
+      writePrefix: jest.fn(),
+      updateStyle(partial) {
+        this.style = { ...this.style, ...partial };
+      },
+      DFS: jest.fn(),
+    };
+
+    const token = {
+      loose: false,
+      task: false,
+      prefix: "\u2022 ",
+      tokens: [{ type: "text", text: "Item" }],
+    };
+
+    writeListItem.call(context, token);
+
+    expect(context.style.skipParagraphBreak).toBe(false);
   });
 
   it("writeList should set bullet prefixes for unordered list", () => {
@@ -164,7 +198,7 @@ describe("md-to-pdf list helpers", () => {
     expect(token.items[1].prefix).toBe("• ");
   });
 
-  it("writeList should break line when starting from mid-line cursor", () => {
+  it("writeList should not add an extra pre-list line break from mid-line cursor", () => {
     const style = ({ ...getDefaultStyle(), ...{ currentWidth: 60, cursorIndex: 90, currentHeight: 80, indent: 8 } });
     const context = {
       style,
@@ -200,7 +234,7 @@ describe("md-to-pdf list helpers", () => {
 
     writeList.call(context, token);
 
-    expect(context.lineBreak).toHaveBeenCalledWith(context.style.lineDistance);
+    expect(context.lineBreak).not.toHaveBeenCalled();
     expect(token.items[0].prefix).toBe("• ");
   });
 

--- a/md-to-pdf/tests/unit_tests/style.test.ts
+++ b/md-to-pdf/tests/unit_tests/style.test.ts
@@ -10,6 +10,7 @@ const {
   popStyle,
   updateStyle,
   setTextStyle,
+  getSpaceBreakCount,
   checkHeight,
   setDocStyle,
 } = require("../../helpers/styles");
@@ -167,7 +168,6 @@ describe("md-to-pdf style helpers", () => {
     setDocStyle(doc, "hello", style);
 
     expect(jspdfFonts.chooseFontForText).toHaveBeenCalledWith("hello", "Times");
-    expect(doc.setFont).toHaveBeenCalledWith("mock-font");
     expect(doc.setFontSize).toHaveBeenCalledWith(12);
     expect(doc.setTextColor).toHaveBeenCalledWith(style.textColor);
     expect(doc.setDrawColor).toHaveBeenCalledWith(style.drawColor);
@@ -181,7 +181,6 @@ describe("md-to-pdf style helpers", () => {
     setDocStyle(doc, "hello", style);
 
     expect(jspdfFonts.chooseFontForText).toHaveBeenCalledWith("hello", null);
-    expect(doc.setFont).toHaveBeenCalledWith("mock-font");
     expect(doc.setFont).toHaveBeenCalledWith("mock-font", "normal");
   });
 
@@ -193,5 +192,18 @@ describe("md-to-pdf style helpers", () => {
 
     expect(doc.setFont).toHaveBeenCalledWith("mock-font", "bold");
     expect(doc.setFont).toHaveBeenCalledWith("mock-font", "normal");
+  });
+
+  it("getSpaceBreakCount should return 1 for non-space tokens", () => {
+    expect(getSpaceBreakCount.call({}, { type: "text", raw: "\n\n\n" })).toBe(1);
+  });
+
+  it("getSpaceBreakCount should convert raw newline count into blank-line count", () => {
+    expect(getSpaceBreakCount.call({}, { type: "space", raw: "\n\n" })).toBe(1);
+    expect(getSpaceBreakCount.call({}, { type: "space", raw: "\n\n\n" })).toBe(2);
+  });
+
+  it("getSpaceBreakCount should default to 1 when raw is missing", () => {
+    expect(getSpaceBreakCount.call({}, { type: "space" })).toBe(1);
   });
 });

--- a/md-to-pdf/tests/unit_tests/table.test.ts
+++ b/md-to-pdf/tests/unit_tests/table.test.ts
@@ -7,9 +7,10 @@ jest.mock("jspdf-autotable", () => ({
 const { processTable } = require("../../helpers/table");
 const { getDefaultStyle } = require("../../helpers/styles");
 const { createMockDoc } = require("../test-utils/mockDoc");
+const { autoTable } = require("jspdf-autotable");
 
 describe("md-to-pdf table helper", () => {
-  it("should process table and increase currentHeight", () => {
+  it("should process table and increase currentHeight without extra pre-break at line start", () => {
     const doc = createMockDoc();
     const context = {
       style: ({ ...getDefaultStyle(), ...{ currentHeight: 70, lineDistance: 10, currentWidth: 60, maxLineWidth: 500 } }),
@@ -40,6 +41,49 @@ describe("md-to-pdf table helper", () => {
     });
 
     expect(context.style.currentHeight).toBeGreaterThan(before);
-    expect(context.lineBreak).toHaveBeenCalled();
+    expect(context.lineBreak).toHaveBeenCalledTimes(1);
+    expect(context.lineBreak).toHaveBeenCalledWith(10);
+    expect(autoTable).toHaveBeenCalledWith(
+      doc,
+      expect.objectContaining({
+        pageBreak: "auto",
+      })
+    );
+  });
+
+  it("should pre-break when table starts mid-line", () => {
+    const doc = createMockDoc();
+    const context = {
+      style: ({
+        ...getDefaultStyle(),
+        ...{ currentHeight: 70, lineDistance: 10, currentWidth: 60, cursorIndex: 90, maxLineWidth: 500 },
+      }),
+      getDoc() {
+        return doc;
+      },
+      getStyle() {
+        return this.style;
+      },
+      setStyle(next) {
+        this.style = next;
+      },
+      lineBreak: jest.fn(function(distance) {
+        this.style = {
+          ...this.style,
+          currentHeight: this.style.currentHeight + distance,
+          cursorIndex: this.style.currentWidth,
+        };
+      }),
+    };
+
+    processTable.call(context, {
+      header: [{ text: "A" }, { text: "B" }],
+      align: ["left", "right"],
+      rows: [[{ text: "1" }, { text: "2" }]],
+    });
+
+    expect(context.lineBreak).toHaveBeenCalledTimes(2);
+    expect(context.lineBreak).toHaveBeenNthCalledWith(1, 10);
+    expect(context.lineBreak).toHaveBeenNthCalledWith(2, 10);
   });
 });

--- a/md-to-pdf/tests/unit_tests/text.test.ts
+++ b/md-to-pdf/tests/unit_tests/text.test.ts
@@ -1,8 +1,47 @@
-const { writeText, writePrefix } = require("../../helpers/text");
+const { chooseSplitWidth, writeText, writePrefix } = require("../../helpers/text");
 const { getDefaultStyle, setDocStyle } = require("../../helpers/styles");
 const { createMockDoc } = require("../test-utils/mockDoc");
 
 describe("md-to-pdf text helpers", () => {
+  describe("chooseSplitWidth", () => {
+    function createDoc(getTextWidth = (value) => String(value).length * 5) {
+      return {
+        getTextWidth: jest.fn(getTextWidth),
+      };
+    }
+
+    it("returns remaining width for empty text", () => {
+      expect(chooseSplitWidth("", 80, 400, createDoc())).toBe(80);
+    });
+
+    it("returns remaining width for whitespace-only text", () => {
+      expect(chooseSplitWidth("   \t  ", 75, 400, createDoc())).toBe(75);
+    });
+
+    it("returns full-line width when first word does not fit remaining width", () => {
+      expect(chooseSplitWidth("Reference Link", 15, 440, createDoc())).toBe(440);
+    });
+
+    it("keeps remaining width for one-word text that already fits", () => {
+      expect(chooseSplitWidth("hello", 80, 400, createDoc())).toBe(80);
+    });
+
+    it("keeps remaining width for single long word that cannot fit even full line", () => {
+      expect(
+        chooseSplitWidth("supercalifragilisticexpialidocious", 30, 440, createDoc(() => 1000))
+      ).toBe(30);
+    });
+
+    it("falls back to full-line width when remaining width is zero or negative", () => {
+      expect(chooseSplitWidth("Reference", 0, 440, createDoc())).toBe(440);
+      expect(chooseSplitWidth("Reference", -10, 440, createDoc())).toBe(440);
+    });
+
+    it("never returns less than 1", () => {
+      expect(chooseSplitWidth("", -10, 0, createDoc())).toBe(1);
+    });
+  });
+
   function createContext(docOverrides = {}, styleOverrides = {}) {
     const doc = createMockDoc(docOverrides);
     const context = {
@@ -70,6 +109,112 @@ describe("md-to-pdf text helpers", () => {
     writeText.call(context, "wrapped");
 
     expect(context.style.currentHeight).toBeGreaterThan(before);
+  });
+
+  it("should render split pieces on separate lines", () => {
+    const { context, doc } = createContext(
+      {
+        splitTextToSize: jest.fn(() => ["naturally in exported", "documents"]),
+        getTextWidth: jest.fn((text) => String(text).length * 5),
+      },
+      {
+        currentWidth: 10,
+        cursorIndex: 10,
+        maxLineWidth: 500,
+        currentHeight: 100,
+        lineDistance: 10,
+      }
+    );
+
+    writeText.call(context, "naturally in exported documents");
+
+    expect(doc.text).toHaveBeenCalledTimes(2);
+    expect(doc.text.mock.calls[0][0]).toBe("naturally in exported");
+    expect(doc.text.mock.calls[1][0]).toBe("documents");
+    expect(doc.text.mock.calls[1][2] - doc.text.mock.calls[0][2]).toBe(10);
+  });
+
+  it("should move to next line before splitting when first word cannot fit remaining width", () => {
+    const { context, doc } = createContext(
+      {
+        splitTextToSize: jest.fn((text, width) => {
+          if (text === "Reference Link" && width === 15) return ["Ref", "ere", "nc", "e", "L", "ink"];
+          if (text === "Reference Link" && width === 440) return ["Reference Link"];
+          return [text];
+        }),
+        getTextWidth: jest.fn((text) => String(text).length * 5),
+      },
+      {
+        currentWidth: 60,
+        cursorIndex: 485,
+        maxLineWidth: 500,
+        currentHeight: 100,
+        lineDistance: 10,
+      }
+    );
+
+    writeText.call(context, "Reference Link");
+
+    expect(doc.splitTextToSize).toHaveBeenCalledWith("Reference Link", 440);
+    expect(doc.text).toHaveBeenCalledTimes(1);
+    expect(doc.text).toHaveBeenCalledWith("Reference Link", 60, 110);
+    expect(context.style.currentHeight).toBe(110);
+    expect(context.style.cursorIndex).toBe(130);
+  });
+
+  it("should split continuation lines using full width after a mid-line wrap", () => {
+    const text = "and enough words to wrap visually across lines in narrow pages";
+    const { context, doc } = createContext(
+      {
+        splitTextToSize: jest.fn((value, width) => {
+          if (value === text && width === 220) {
+            return ["and enough words to", "wrap visually across", "lines in narrow pages"];
+          }
+          if (value === "lines in narrow pages" && width === 440) {
+            return ["lines in narrow pages"];
+          }
+          return [value];
+        }),
+        getTextWidth: jest.fn((value) => String(value).length * 5),
+      },
+      {
+        currentWidth: 60,
+        cursorIndex: 280,
+        maxLineWidth: 500,
+        currentHeight: 100,
+        lineDistance: 10,
+      }
+    );
+
+    writeText.call(context, text);
+
+    expect(doc.splitTextToSize).toHaveBeenCalledWith(text, 220);
+    expect(doc.splitTextToSize).toHaveBeenCalledWith("lines in narrow pages", 440);
+    expect(doc.text).toHaveBeenCalledTimes(2);
+    expect(doc.text.mock.calls[0][0]).toBe("and enough words to wrap visually across ");
+    expect(doc.text.mock.calls[1][0]).toBe("lines in narrow pages");
+  });
+
+  it("should advance line when wrapped output has a trailing empty piece", () => {
+    const { context } = createContext(
+      {
+        splitTextToSize: jest.fn(() => ["3.", ""]),
+        getTextWidth: jest.fn((text) => (text === "3." ? 10 : 0)),
+      },
+      {
+        currentWidth: 60,
+        cursorIndex: 60,
+        maxLineWidth: 500,
+        currentHeight: 100,
+        lineDistance: 10,
+      }
+    );
+
+    const before = context.style.currentHeight;
+
+    writeText.call(context, "3. ");
+
+    expect(context.style.currentHeight).toBe(before + 10);
   });
 
   it("writePrefix should prepend token prefix", () => {

--- a/md-to-pdf/types.ts
+++ b/md-to-pdf/types.ts
@@ -10,8 +10,8 @@ export type MarkdownCheckboxToken = (Tokens.Checkbox | Tokens.ListItem) & {
   prefix?: string;
   checked?: boolean;
 };
-export type MarkdownListToken = Tokens.List;
 export type MarkdownListItemToken = Tokens.ListItem & { prefix?: string };
+export type MarkdownListToken = Omit<Tokens.List, "items"> & { items: MarkdownListItemToken[] };
 export type MarkdownCodeSpanToken = Tokens.Codespan;
 export type MarkdownCodeToken = Tokens.Code & { lines?: string[] };
 export type MarkdownTableToken = Tokens.Table;
@@ -69,6 +69,7 @@ export interface MarkdownToPdfContext {
   popStyle: () => void;
   updateStyle: (partial?: Partial<PdfStyle>) => void;
   setTextStyle: (type: string) => void;
+  getSpaceBreakCount: (token: MarkdownToken) => number;
   writeText: (text: string) => PdfStyle;
   writePrefix: (token: MarkdownListItemToken | MarkdownCheckboxToken) => PdfStyle;
   lineBreak: (distance: number) => void;
@@ -80,6 +81,7 @@ export interface MarkdownToPdfContext {
   writeListItem: (token: MarkdownListItemToken) => void;
   writeCode: (token: MarkdownCodeToken) => void;
   writeCodeSpan: (token: MarkdownCodeSpanToken) => void;
+  writeHtml: (token: MarkdownToken) => void;
   writeBlockquote: (token: MarkdownBlockquoteToken) => void;
   writeHeading: (token: MarkdownHeadingToken) => void;
   writeParagraph: (token: MarkdownParagraphToken) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-document-converter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-document-converter",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-document-converter",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Convert Markdown text to Microsoft Word (.docx) documents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
    fix: improve markdown rendering consistency across PDF and DOCX
    - preserve newline handling in DOCX text runs and child token spacing
    - improve PDF text wrapping with chooseSplitWidth and full-width continuation wrapping
    - extract HTML rendering to writeHtml helper and bind via MarkdownToPdf instance
    - preserve blank lines after block HTML in PDF output
    - refine list/table spacing behavior and space token newline handling
    - expand unit and integration test coverage for rendering regressions
    - bump package version to 1.0.5