### PR TITLE
bugfix/html-mdf: resolved spacing issues before/after block html tokens

### DIFF
--- a/md-to-pdf/MarkdownToPdf.ts
+++ b/md-to-pdf/MarkdownToPdf.ts
@@ -13,7 +13,7 @@ import { processTable } from "./helpers/table";
 import { writeCheckBox, writeList, writeListItem } from "./helpers/list";
 import { writeCode, writeCodeSpan } from "./helpers/code";
 import { writeBlockquote } from "./helpers/blockquote";
-import { writeHtml } from "./helpers/html";
+import { expandBlockHtmlTokens } from "./helpers/html";
 import { writeHeading } from "./helpers/heading";
 import { writeLink } from "./helpers/link";
 import { writeParagraph } from "./helpers/paragraph";
@@ -83,7 +83,6 @@ export class MarkdownToPdf {
   public writeListItem: (token: MarkdownListItemToken) => void;
   public writeCode: (token: MarkdownCodeToken) => void;
   public writeCodeSpan: (token: MarkdownCodeSpanToken) => void;
-  public writeHtml: (token: MarkdownToken) => void;
   public writeBlockquote: (token: MarkdownBlockquoteToken) => void;
   public writeHeading: (token: MarkdownHeadingToken) => void;
   public writeParagraph: (token: MarkdownParagraphToken) => void;
@@ -118,7 +117,6 @@ export class MarkdownToPdf {
     this.writeListItem = writeListItem.bind(this);
     this.writeCode = writeCode.bind(this);
     this.writeCodeSpan = writeCodeSpan.bind(this);
-    this.writeHtml = writeHtml.bind(this);
     this.writeBlockquote = writeBlockquote.bind(this);
     this.writeHeading = writeHeading.bind(this);
     this.writeLink = writeLink.bind(this);
@@ -242,6 +240,10 @@ export class MarkdownToPdf {
 
     // parse markdown text into tokens using marked (with GitHub-flavoured Markdown and line breaks enabled)
     const tokens: MarkdownTokensList = marked.lexer(normalizedText, { gfm: true, breaks: true });
+
+    // Expand greedy block HTML tokens into individual paragraph tokens so line
+    // structure is preserved in the PDF layout.
+    expandBlockHtmlTokens(tokens);
 
     // decode HTML text and split code lines
     marked.walkTokens(tokens, (token: MarkdownToken) => {

--- a/md-to-pdf/helpers/html.ts
+++ b/md-to-pdf/helpers/html.ts
@@ -1,4 +1,4 @@
-import type { MarkdownToPdfContext, MarkdownToken } from "../types";
+import type { MarkdownToken } from "../types";
 
 export function getLiteralTokenText(token: MarkdownToken): string {
   if ("raw" in token && token.raw && typeof token.raw === "string") {
@@ -11,27 +11,45 @@ export function getLiteralTokenText(token: MarkdownToken): string {
   return "";
 }
 
-function getTrailingNewlineCount(raw: string): number {
-  // Only trailing newlines matter for spacing after a rendered HTML block.
-  const match = String(raw || "").match(/\n+$/);
-
-  return match ? match[0].length : 0;
+function isBlockHtml(token: MarkdownToken): boolean {
+  return token.type === "html" && "block" in token && Boolean((token as Record<string, unknown>).block);
 }
 
-export function writeHtml(this: MarkdownToPdfContext, token: MarkdownToken): void {
-  // Keep raw HTML visible in output instead of dropping unsupported tokens.
-  const rawText = getLiteralTokenText(token);
-  this.writeText(rawText);
+function toParagraph(line: string): MarkdownToken {
+  return {
+    type: "paragraph" as const,
+    raw: line,
+    text: line,
+    tokens: [{ type: "text" as const, raw: line, text: line, escaped: false }],
+  };
+}
 
-  // Block HTML tokens can carry trailing newlines in `raw`. Preserve blank
-  // lines that would otherwise be lost when rendered as literal text.
-  const isBlockHtml = "block" in token && Boolean((token as any).block);
-  if (isBlockHtml) {
-    const trailingNewlines = getTrailingNewlineCount(rawText);
-    const extraBreaks = Math.max(0, trailingNewlines - 1);
+// One space token per blank line, using "\n\n" to match Marked's natural encoding.
+function addSpace(): MarkdownToken {
+  return { type: "space" as const, raw: "\n\n" };
+}
 
-    for (let i = 0; i < extraBreaks; i += 1) {
-      this.lineBreak(this.getStyle().lineDistance);
+// Marked greedily absorbs everything after a block HTML tag (e.g. <div>) into
+// a single html token, including unrelated plain-text lines that follow. Expand
+// each block html token into one token per line, preserving blank lines as space
+// tokens.
+export function expandBlockHtmlTokens(tokens: MarkdownToken[]): void {
+  for (let i = tokens.length - 1; i >= 0; i -= 1) {
+    if (!isBlockHtml(tokens[i])) continue;
+
+    const replacement: MarkdownToken[] = [];
+    // Marked's block HTML raw always ends with the "\n\n" blank-line delimiter it
+    // consumed. Strip one trailing "\n" so split("\n") produces one empty string
+    // per blank line instead of two, matching the spacing of inline tags like <em>.
+    for (const line of getLiteralTokenText(tokens[i]).replace(/\n$/, "").split("\n")) {
+      if (!line) {
+        replacement.push(addSpace());
+      } else {
+        replacement.push(toParagraph(line));
+      }
     }
+
+    // Replace the single block html token at index i with the expanded tokens.
+    tokens.splice(i, 1, ...replacement);
   }
 }

--- a/md-to-pdf/processors/child.ts
+++ b/md-to-pdf/processors/child.ts
@@ -37,11 +37,6 @@ export function processChild(this: MarkdownToPdfContext, token: MarkdownToken): 
     case "hr":
       this.horizontalLine();
       break;
-    // Render raw HTML tokens as literal text so content is not silently lost.
-    case "html": {
-      this.writeHtml(token);
-      break;
-    }
     // image
     case "image":
       this.writeLink(token as MarkdownLinkToken);

--- a/md-to-pdf/tests/MarkdownToPdf.test.ts
+++ b/md-to-pdf/tests/MarkdownToPdf.test.ts
@@ -45,7 +45,6 @@ describe("MarkdownToPdf class", () => {
     expect(typeof pdf.setTextStyle).toBe("function");
     expect(typeof pdf.getSpaceBreakCount).toBe("function");
     expect(typeof pdf.writeText).toBe("function");
-    expect(typeof pdf.writeHtml).toBe("function");
     expect(typeof pdf.lineBreak).toBe("function");
     expect(typeof pdf.horizontalLine).toBe("function");
     expect(typeof pdf.processParent).toBe("function");

--- a/md-to-pdf/tests/integration/convert.integration.test.ts
+++ b/md-to-pdf/tests/integration/convert.integration.test.ts
@@ -131,12 +131,14 @@ describe("integration: markdown to pdf", () => {
       lineSpc: 18,
     });
 
-    const htmlCall = doc.text.mock.calls.find((call) => String(call[0]).includes("</div>"));
+    // expandBlockHtmlTokens expands the html token into a paragraph whose text
+    // is the raw tag string, followed by a space token for the blank line.
+    const divCall = doc.text.mock.calls.find((call) => String(call[0]).includes("</div>"));
     const paragraphCall = doc.text.mock.calls.find((call) => String(call[0]) === "This is text");
 
-    expect(htmlCall).toBeDefined();
+    expect(divCall).toBeDefined();
     expect(paragraphCall).toBeDefined();
-    expect(paragraphCall[2] - htmlCall[2]).toBe(20);
+    expect(paragraphCall[2] - divCall[2]).toBe(20);
   });
 
   it("should not insert an extra blank line before nested list items", () => {

--- a/md-to-pdf/tests/processors/child.test.ts
+++ b/md-to-pdf/tests/processors/child.test.ts
@@ -11,7 +11,6 @@ describe("md-to-pdf child processor", () => {
       writeCheckBox: jest.fn(),
       writeCode: jest.fn(),
       writeCodeSpan: jest.fn(),
-      writeHtml: jest.fn(),
       horizontalLine: jest.fn(),
       writeLink: jest.fn(),
       writeList: jest.fn(),
@@ -79,15 +78,12 @@ describe("md-to-pdf child processor", () => {
     expect(context.writeText).toHaveBeenCalledWith("hello");
   });
 
-  it("should render html tokens as literal text", () => {
-    processChild.call(context, { type: "html", raw: "<div class=\"note\">x</div>" });
+  it("should write inline html token text via fallback", () => {
+    // Block html tokens are expanded to paragraphs before DFS; only inline html
+    // tokens (block: false) can reach processChild, and they fall through to the
+    // default text handler.
+    processChild.call(context, { type: "html", text: "<b>hello</b>", raw: "<b>hello</b>" });
 
-    expect(context.writeHtml).toHaveBeenCalledWith({ type: "html", raw: "<div class=\"note\">x</div>" });
-  });
-
-  it("should preserve blank line after block html with trailing newlines", () => {
-    processChild.call(context, { type: "html", block: true, raw: "<div>x</div>\n\n" });
-
-    expect(context.writeHtml).toHaveBeenCalledWith({ type: "html", block: true, raw: "<div>x</div>\n\n" });
+    expect(context.writeText).toHaveBeenCalledWith("<b>hello</b>");
   });
 });

--- a/md-to-pdf/types.ts
+++ b/md-to-pdf/types.ts
@@ -81,7 +81,6 @@ export interface MarkdownToPdfContext {
   writeListItem: (token: MarkdownListItemToken) => void;
   writeCode: (token: MarkdownCodeToken) => void;
   writeCodeSpan: (token: MarkdownCodeSpanToken) => void;
-  writeHtml: (token: MarkdownToken) => void;
   writeBlockquote: (token: MarkdownBlockquoteToken) => void;
   writeHeading: (token: MarkdownHeadingToken) => void;
   writeParagraph: (token: MarkdownParagraphToken) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markdown-document-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markdown-document-converter",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "he": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-document-converter",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Convert Markdown text to Microsoft Word (.docx) documents.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -19,7 +19,7 @@
     "build:watch": "tsc -p tsconfig.json --watch",
     "minify": "node scripts/minify-dist.js",
     "prepare": "npm run build && npm run minify",
-    "test": "jest"
+    "test": "jest --runInBand"
   },
   "files": [
     "dist",


### PR DESCRIPTION
fix(md-to-pdf): preserve line structure around block HTML tags
- add expandBlockHtmlTokens() to split block html tokens into paragraph/space tokens
- for pdf, remove dead writeHtml method, constructor binding, and html case in processChild
- update child.test.ts, MarkdownToPdf.test.ts, and integration test to match
- added runInBand to npm test to speed up jest test running