### PR TITLE
bugfix/56635 - fix spacing errors caused by unhandled characters

### DIFF
--- a/md-to-docx/MarkdownToDocx.ts
+++ b/md-to-docx/MarkdownToDocx.ts
@@ -42,7 +42,13 @@ import type {
   MarkdownTokensList,
 } from "./types";
 
+// Matches non-printing control/format characters that can destabilize
+// markdown tokenization or produce noisy output in generated documents.
+const INVISIBLE_FORMAT_AND_CONTROL_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\uFFFD\p{Cf}\p{Cs}\u034F]/gu;
+
 function normalizeMarkdownInput(text: string): string {
+  // Decode entities once here (before lexing) so parsing and output are based
+  // on one canonical input string. We intentionally avoid per-token decode.
   return he.decode(String(text || ""))
     // Normalize line endings first.
     .replace(/\r\n?/g, "\n")
@@ -59,7 +65,7 @@ function normalizeMarkdownInput(text: string): string {
     .replace(/[\u2193\u21D3]/g, "v")
     .replace(/[\u2194\u21D4]/g, "<->")
     // Drop invisible/control characters that commonly corrupt markdown parsing.
-    .replace(/[\u0000\u200B\u2060\uFEFF]/g, "");
+    .replace(INVISIBLE_FORMAT_AND_CONTROL_RE, "");
 }
 
 export class MarkdownToDocx {
@@ -247,14 +253,14 @@ export class MarkdownToDocx {
       },
     ]
       */
+    // normalizeMarkdownInput handles entity decoding and aggressive cleanup
+    // before marked.lexer, which keeps token content deterministic.
     const normalizedText = normalizeMarkdownInput(text);
     const tokens: MarkdownTokensList = marked.lexer(normalizedText, { gfm: true, breaks: true });
 
-    // decode HTML text and split code lines
+    // walkTokens is now only used for code-line preparation.
+    // Text token decode/sanitize is intentionally pre-lexer.
     marked.walkTokens(tokens, (token: MarkdownToken) => {
-      if ("text" in token && typeof token.text === "string") {
-        token.text = he.decode(token.text);
-      }
       if (token.type === "code" && "text" in token && typeof token.text === "string") {
         (token as MarkdownCodeToken).lines = token.text.split("\n");
       }

--- a/md-to-docx/tests/MarkdownToDocx.test.ts
+++ b/md-to-docx/tests/MarkdownToDocx.test.ts
@@ -192,12 +192,12 @@ describe("MarkdownToDocx class", () => {
       expect(marked.walkTokens).toHaveBeenCalled();
     });
 
-    it("should decode HTML entities in token text", () => {
+    it("should decode HTML entities in input before lexing", () => {
       const doc = new MarkdownToDocx();
       const tokens = [{ text: "&lt;test&gt;" }];
       marked.lexer.mockReturnValue(tokens);
 
-      doc.convert("test");
+      doc.convert("&lt;test&gt;");
 
       expect(he.decode).toHaveBeenCalledWith("&lt;test&gt;");
     });
@@ -360,7 +360,7 @@ describe("MarkdownToDocx class", () => {
       expect(Array.isArray(result2)).toBe(true);
     });
 
-    it("should call he.decode for all text tokens", () => {
+    it("should call he.decode for source input once", () => {
       const doc = new MarkdownToDocx();
       const tokens = [
         { text: "hello", type: "text" },
@@ -368,10 +368,10 @@ describe("MarkdownToDocx class", () => {
       ];
       marked.lexer.mockReturnValue(tokens);
 
-      doc.convert("test");
+      doc.convert("hello &amp; world");
 
-      expect(he.decode).toHaveBeenCalledWith("hello");
-      expect(he.decode).toHaveBeenCalledWith("world");
+      expect(he.decode).toHaveBeenCalledTimes(1);
+      expect(he.decode).toHaveBeenCalledWith("hello &amp; world");
     });
 
     it("should process all token types via walkTokens", () => {

--- a/md-to-pdf/MarkdownToPdf.ts
+++ b/md-to-pdf/MarkdownToPdf.ts
@@ -42,7 +42,14 @@ import type {
   PdfStyle,
 } from "./types";
 
+// Matches non-printing control/format characters that are known to create
+// malformed token streams or bad glyph output in PDF rendering.
+const INVISIBLE_FORMAT_AND_CONTROL_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F\uFFFD\p{Cf}\p{Cs}\u034F]/gu;
+
 function normalizeMarkdownInput(text: string): string {
+  // Decode entities once here (before lexing) so both parsing and rendering
+  // operate on the same normalized text. We intentionally do not decode again
+  // per token in walkTokens.
   return he.decode(String(text || ""))
     // Normalize line endings first.
     .replace(/\r\n?/g, "\n")
@@ -58,8 +65,10 @@ function normalizeMarkdownInput(text: string): string {
     .replace(/[\u2192\u21D2]/g, "->")
     .replace(/[\u2193\u21D3]/g, "v")
     .replace(/[\u2194\u21D4]/g, "<->")
-    // Drop invisible/control characters that commonly corrupt markdown parsing.
-    .replace(/[\u0000\u200B\u2060\uFEFF]/g, "");
+    // Drop invisible Unicode format chars and control chars that commonly
+    // survive HTML decoding and then corrupt markdown parsing or PDF layout.
+    // Preserve tabs/newlines because markdown uses them structurally.
+    .replace(INVISIBLE_FORMAT_AND_CONTROL_RE, "");
 }
 
 export class MarkdownToPdf {
@@ -229,6 +238,8 @@ export class MarkdownToPdf {
       },
     ]
       */
+    // normalizeMarkdownInput performs entity decoding and aggressive cleanup
+    // before marked.lexer so all downstream tokenization sees stable input.
     const normalizedText = normalizeMarkdownInput(text);
 
     // set the active document and reset traversal style stack
@@ -245,11 +256,9 @@ export class MarkdownToPdf {
     // structure is preserved in the PDF layout.
     expandBlockHtmlTokens(tokens);
 
-    // decode HTML text and split code lines
+    // Keep walkTokens focused on structural code-line splitting only.
+    // Text token decode/sanitize is intentionally handled pre-lexer.
     marked.walkTokens(tokens, (token: MarkdownToken) => {
-      if ("text" in token && typeof token.text === "string") {
-        token.text = he.decode(token.text);
-      }
       if (token.type === "code" && "text" in token && typeof token.text === "string") {
         (token as MarkdownCodeToken).lines = token.text.split("\n");
       }

--- a/md-to-pdf/tests/MarkdownToPdf.test.ts
+++ b/md-to-pdf/tests/MarkdownToPdf.test.ts
@@ -73,6 +73,21 @@ describe("MarkdownToPdf class", () => {
     expect(marked.lexer).toHaveBeenCalledWith("A B C-DE\nF\nG", { gfm: true, breaks: true });
   });
 
+  it("should strip decoded HTML format and bidi control characters before parsing", () => {
+    const realHe = jest.requireActual("he");
+    he.decode.mockImplementation(realHe.decode);
+
+    const pdf = new MarkdownToPdf();
+    const doc = createMockDoc();
+
+    pdf.convert(
+      doc,
+      "A&zwj;B&zwnj;C&lrm;D&rlm;E&#x2066;F&#x2069;G&#x034F;H&#x0007;I&#xFEFF;J&#xD800;K"
+    );
+
+    expect(marked.lexer).toHaveBeenCalledWith("ABCDEFGHIJK", { gfm: true, breaks: true });
+  });
+
   it("should normalize arrow entities to ASCII fallbacks before parsing", () => {
     const realHe = jest.requireActual("he");
     he.decode.mockImplementation(realHe.decode);
@@ -100,7 +115,7 @@ describe("MarkdownToPdf class", () => {
     expect(normalizedInput).not.toMatch(/[\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]/);
   });
 
-  it("should decode token text and split code lines", () => {
+  it("should decode input text and split code lines", () => {
     const tokens = [
       { type: "text", text: "&lt;value&gt;" },
       { type: "code", text: "a\nb" },
@@ -112,7 +127,7 @@ describe("MarkdownToPdf class", () => {
 
     pdf.convert(doc, "markdown");
 
-    expect(he.decode).toHaveBeenCalledWith("&lt;value&gt;");
+    expect(he.decode).toHaveBeenCalledWith("markdown");
     expect(tokens[1].lines).toEqual(["a", "b"]);
   });
 

--- a/md-to-pdf/tests/unit_tests/style.test.ts
+++ b/md-to-pdf/tests/unit_tests/style.test.ts
@@ -26,6 +26,16 @@ describe("md-to-pdf style helpers", () => {
     expect(typeof actualJspdfFonts.chooseFontForText).toBe("function");
   });
 
+  it("chooseFontForText should route symbol-heavy text to NotoSerif", () => {
+    expect(actualJspdfFonts.chooseFontForText("Decimal: A ☃", "helvetica")).toBe("NotoSerif");
+    expect(actualJspdfFonts.chooseFontForText("Text and emoji variation selector pairs: ✈︎ ✈️ ♥︎ ❤️", "helvetica")).toBe("NotoSerif");
+  });
+
+  it("chooseFontForText should route combining-mark text to NotoSerif", () => {
+    expect(actualJspdfFonts.chooseFontForText("Simple combining marks: á ê ï ō ů ñ", "helvetica")).toBe("NotoSerif");
+    expect(actualJspdfFonts.chooseFontForText("Repeated combining marks: Z̴̷̸͓͔͕a̵̶̷͙͚l̴̵͍g̵͔o̶͍", "helvetica")).toBe("NotoSerif");
+  });
+
   it("should return default style", () => {
     const style = getDefaultStyle();
 


### PR DESCRIPTION
bugfix/56635 - fix spacing errors caused by unhandled characters

- Move `he.decode` to `normalizeMarkdownInput` instead of performing it on a per-token basis
- Introduce and use `INVISIBLE_FORMAT_AND_CONTROL_RE` to strip control, format, surrogate, and replacement characters during `normalizeMarkdownInput`
- Improve script detection and font routing in `md-to-pdf/jspdfFonts.ts` so symbol/combining/non-latin edge cases resolve to NotoSerif instead of latin fallback
- Update tests to match new behaviour